### PR TITLE
[WIP] fetch ephemeral keys at runtime and use them in Clerk functions and components for Next.JS

### DIFF
--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -1,3 +1,4 @@
+import { fetchEphemeralKeys } from '@clerk/shared';
 import { ClerkAPIResponseError, parseError } from '@clerk/shared/error';
 import type { ClerkAPIError, ClerkAPIErrorJSON } from '@clerk/types';
 import snakecaseKeys from 'snakecase-keys';
@@ -56,6 +57,11 @@ type BuildRequestOptions = {
 };
 export function buildRequest(options: BuildRequestOptions) {
   const requestFn = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
+    if (!options.secretKey) {
+      const keys = await fetchEphemeralKeys();
+      options.secretKey = keys.secretKey;
+    }
+
     const { secretKey, apiUrl = API_URL, apiVersion = API_VERSION, userAgent = USER_AGENT } = options;
     const { path, method, queryParams, headerParams, bodyParams, formData } = requestOptions;
 

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -58,7 +58,8 @@ type BuildRequestOptions = {
 export function buildRequest(options: BuildRequestOptions) {
   const requestFn = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
     if (!options.secretKey) {
-      const keys = await fetchEphemeralKeys();
+      // Need to figure this out
+      const keys = await fetchEphemeralKeys({ appUrl: 'buildRequest' });
       options.secretKey = keys.secretKey;
     }
 

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -18,6 +18,8 @@ const Cookies = {
   ClientUat: '__client_uat',
   Handshake: '__clerk_handshake',
   DevBrowser: '__clerk_db_jwt',
+  EphemeralMode: '__clerk_ephemeral_mode',
+  PublishableKey: '__clerk_publishable_key',
 } as const;
 
 const QueryParameters = {

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -1,4 +1,6 @@
+import { constants } from '@clerk/backend/internal';
 import type { InitialState, Without } from '@clerk/types';
+import { cookies } from 'next/headers';
 import React from 'react';
 
 import type { NextClerkProviderProps } from '../../types';
@@ -6,13 +8,19 @@ import { mergeNextClerkPropsWithEnv } from '../../utils/mergeNextClerkPropsWithE
 import { ClientClerkProvider } from '../client/ClerkProvider';
 import { initialState } from './auth';
 
+const fetchEphemeralCookie = () => {
+  const { get } = cookies();
+  return get(constants.Cookies.PublishableKey)?.value;
+};
+
 export function ClerkProvider(props: Without<NextClerkProviderProps, '__unstable_invokeMiddlewareOnAuthStateChange'>) {
   const { children, ...rest } = props;
   const state = initialState()?.__clerk_ssr_state as InitialState;
+  const publishableKey = rest.publishableKey || fetchEphemeralCookie();
 
   return (
     <ClientClerkProvider
-      {...mergeNextClerkPropsWithEnv(rest)}
+      {...mergeNextClerkPropsWithEnv({ ...rest, publishableKey })}
       initialState={state}
     >
       {children}

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -72,8 +72,8 @@ interface ClerkMiddleware {
 export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
   const [request, event] = parseRequestAndEvent(args);
   const [handler, params] = parseHandlerAndOptions(args);
-  const publishableKey: string | undefined = params.publishableKey || PUBLISHABLE_KEY;
-  const secretKey: string | undefined = params.secretKey || SECRET_KEY;
+  const publishableKey: string = params.publishableKey || PUBLISHABLE_KEY;
+  const secretKey: string = params.secretKey || SECRET_KEY;
 
   const signInUrl = params.signInUrl || SIGN_IN_URL;
   const signUpUrl = params.signUpUrl || SIGN_UP_URL;
@@ -104,8 +104,8 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
       options.ephemeral = true;
     }
 
-    assertKey(options.publishableKey || '', () => errorThrower.throwMissingPublishableKeyError());
-    assertKey(options.secretKey || '', () => errorThrower.throwMissingSecretKeyError());
+    assertKey(options.publishableKey, () => errorThrower.throwMissingPublishableKeyError());
+    assertKey(options.secretKey, () => errorThrower.throwMissingSecretKeyError());
 
     const clerkRequest = createClerkRequest(request);
 

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -98,7 +98,7 @@ export const clerkMiddleware: ClerkMiddleware = (...args: unknown[]): any => {
 
   const nextMiddleware: NextMiddleware = async (request, event) => {
     if (!options.publishableKey || !options.secretKey) {
-      const keys = await fetchEphemeralKeys();
+      const keys = await fetchEphemeralKeys({ appUrl: request.url });
       options.publishableKey = keys.publishableKey;
       options.secretKey = keys.secretKey;
       options.ephemeral = true;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -16,3 +16,5 @@ export const STAGING_ENV_SUFFIXES = ['.accountsstage.dev'];
 export const LOCAL_API_URL = 'https://api.lclclerk.com';
 export const STAGING_API_URL = 'https://api.clerkstage.dev';
 export const PROD_API_URL = 'https://api.clerk.com';
+export const APP_URL_HEADER = 'x-clerk-app-url';
+export const EPHEMERAL_KEY_URL = 'http://localhost:8787/auth.json';

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -1,6 +1,6 @@
 import type { PublishableKey } from '@clerk/types';
 
-import { DEV_OR_STAGING_SUFFIXES, LEGACY_DEV_INSTANCE_SUFFIXES } from './constants';
+import { APP_URL_HEADER, DEV_OR_STAGING_SUFFIXES, EPHEMERAL_KEY_URL, LEGACY_DEV_INSTANCE_SUFFIXES } from './constants';
 import { isomorphicAtob } from './isomorphicAtob';
 import { isomorphicBtoa } from './isomorphicBtoa';
 
@@ -119,9 +119,14 @@ type EphemeralKeys = {
 export const fetchEphemeralKeys = (() => {
   let keys: EphemeralKeys | null = null;
 
-  return async () => {
+  return async ({ appUrl }: { appUrl: string }) => {
     if (!keys) {
-      const response = await fetch('http://localhost:8787/auth.json');
+      const response = await fetch(EPHEMERAL_KEY_URL, {
+        headers: {
+          'Content-Type': 'application/json',
+          [APP_URL_HEADER]: appUrl,
+        },
+      });
       const data = await response.json();
       keys = {
         publishableKey: data.publishable_key,

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -109,3 +109,25 @@ export function isDevelopmentFromSecretKey(apiKey: string): boolean {
 export function isProductionFromSecretKey(apiKey: string): boolean {
   return apiKey.startsWith('live_') || apiKey.startsWith('sk_live_');
 }
+
+type EphemeralKeys = {
+  publishableKey: string;
+  secretKey: string;
+};
+
+// TODO: Use a real API endpoint
+export const fetchEphemeralKeys = (() => {
+  let keys: EphemeralKeys | null = null;
+
+  return async () => {
+    if (!keys) {
+      const response = await fetch('http://localhost:8787');
+      const data = await response.json();
+      keys = {
+        publishableKey: data.publishable_key,
+        secretKey: data.secret_key,
+      };
+    }
+    return keys;
+  };
+})();

--- a/packages/shared/src/keys.ts
+++ b/packages/shared/src/keys.ts
@@ -121,7 +121,7 @@ export const fetchEphemeralKeys = (() => {
 
   return async () => {
     if (!keys) {
-      const response = await fetch('http://localhost:8787');
+      const response = await fetch('http://localhost:8787/auth.json');
       const data = await response.json();
       keys = {
         publishableKey: data.publishable_key,


### PR DESCRIPTION
Fetches ephemeral keys from a server when keys are not set.

Currently the middleware is handling this, we'll need to see if we can pass the publishable key to the front end (maybe pull it into the DOM?)

We also need to test what else we need to implement in Next's backend to use the secret key.

- [ ] test that server keys are implemented correctly
- [ ] test that client keys are implemented correctly

vvvv Clerk Template Below vvvv

## Description

<!-- 
  Thanks for contributing to Clerk. Make sure to read the contributing guide at https://github.com/clerk/javascript/blob/main/docs/CONTRIBUTING.md before opening a PR!

  **Please create a feature request before starting work on any significant change.**

  Write a brief description of the changes introduced in this PR.
  Include screenshots/videos if they help convey the change.

  Also explain how one can test the change.
-->

<!-- Fixes #(issue number) -->

## Checklist

- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
