### PR TITLE
feat(nextjs): add ephemeral mode

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,10 @@
         "import": "./dist/runtime/node/crypto.mjs"
       },
       "default": "./dist/runtime/browser/crypto.mjs"
+    },
+    "#ephemeral": {
+      "node": "./dist/runtime/node/ephemeral.js",
+      "default": "./dist/runtime/browser/ephemeral.js"
     }
   },
   "exports": {

--- a/packages/backend/src/__tests__/exports.test.ts
+++ b/packages/backend/src/__tests__/exports.test.ts
@@ -38,6 +38,7 @@ export default (QUnit: QUnit) => {
         'createRedirect',
         'debugRequestState',
         'decorateObjectWithResources',
+        'fetchEphemeralAccount',
         'makeAuthObjectSerializable',
         'signedInAuthObject',
         'signedOutAuthObject',

--- a/packages/backend/src/api/request.ts
+++ b/packages/backend/src/api/request.ts
@@ -56,6 +56,14 @@ type BuildRequestOptions = {
 };
 export function buildRequest(options: BuildRequestOptions) {
   const requestFn = async <T>(requestOptions: ClerkBackendApiRequestOptions): Promise<ClerkBackendApiResponse<T>> => {
+    // TODO: Remove this once we have a better way to handle ephemeral keys
+    if (!options.secretKey && !!process && process.env.NODE_ENV === 'development') {
+      const ephemeralAccount = await runtime.fetchEphemeralAccount();
+      if (ephemeralAccount) {
+        options.secretKey = ephemeralAccount.secretKey;
+      }
+    }
+
     const { secretKey, apiUrl = API_URL, apiVersion = API_VERSION, userAgent = USER_AGENT } = options;
     const { path, method, queryParams, headerParams, bodyParams, formData } = requestOptions;
 

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -19,6 +19,8 @@ const Cookies = {
   ClientUat: '__client_uat',
   Handshake: '__clerk_handshake',
   DevBrowser: '__clerk_db_jwt',
+  EphemeralPublishableKey: '__clerk_ephemeral_publishable_key',
+  EphemeralSecretKey: '__clerk_ephemeral_secret_key',
 } as const;
 
 const QueryParameters = {
@@ -29,6 +31,8 @@ const QueryParameters = {
   Handshake: Cookies.Handshake,
   HandshakeHelp: '__clerk_help',
   LegacyDevBrowser: '__dev_session',
+  EphemeralPublishableKey: '__clerk_ephemeral_publishable_key',
+  EphemeralSecretKey: '__clerk_ephemeral_secret_key',
 } as const;
 
 const Headers = {

--- a/packages/backend/src/internal.ts
+++ b/packages/backend/src/internal.ts
@@ -2,25 +2,26 @@ export { constants } from './constants';
 export { createRedirect } from './createRedirect';
 export type { RedirectFun } from './createRedirect';
 
-export type { CreateAuthenticateRequestOptions } from './tokens/factory';
 export { createAuthenticateRequest } from './tokens/factory';
+export type { CreateAuthenticateRequestOptions } from './tokens/factory';
 
 export { debugRequestState } from './tokens/request';
 
 export type { AuthenticateRequestOptions } from './tokens/types';
 
+export { makeAuthObjectSerializable, signedInAuthObject, signedOutAuthObject } from './tokens/authObjects';
 export type {
-  SignedInAuthObjectOptions,
-  SignedInAuthObject,
-  SignedOutAuthObject,
   AuthObject,
+  SignedInAuthObject,
+  SignedInAuthObjectOptions,
+  SignedOutAuthObject,
 } from './tokens/authObjects';
-export { makeAuthObjectSerializable, signedOutAuthObject, signedInAuthObject } from './tokens/authObjects';
 
 export { AuthStatus } from './tokens/authStatus';
 export type { RequestState, SignedInState, SignedOutState } from './tokens/authStatus';
 
 export { decorateObjectWithResources, stripPrivateDataFromObject } from './util/decorateObjectWithResources';
+export { fetchEphemeralAccount } from './util/fetchEphemeralAccount';
 
 export { createClerkRequest } from './tokens/clerkRequest';
 export type { ClerkRequest } from './tokens/clerkRequest';

--- a/packages/backend/src/runtime.ts
+++ b/packages/backend/src/runtime.ts
@@ -14,10 +14,13 @@
 
 // @ts-ignore - These are package subpaths
 import { webcrypto as crypto } from '#crypto';
+// @ts-ignore - These are package subpaths
+import { fetchEphemeralAccount } from '#ephemeral';
 
 type Runtime = {
   crypto: Crypto;
   fetch: typeof globalThis.fetch;
+  fetchEphemeralAccount: typeof fetchEphemeralAccount;
   AbortController: typeof globalThis.AbortController;
   Blob: typeof globalThis.Blob;
   FormData: typeof globalThis.FormData;
@@ -38,6 +41,7 @@ const globalFetch = fetch.bind(globalThis);
 const runtime: Runtime = {
   crypto,
   fetch: globalFetch,
+  fetchEphemeralAccount,
   AbortController: globalThis.AbortController,
   Blob: globalThis.Blob,
   FormData: globalThis.FormData,

--- a/packages/backend/src/runtime/browser/ephemeral.js
+++ b/packages/backend/src/runtime/browser/ephemeral.js
@@ -1,0 +1,5 @@
+async function fetchEphemeralAccount() {
+  return null;
+}
+
+export { fetchEphemeralAccount };

--- a/packages/backend/src/runtime/node/ephemeral.js
+++ b/packages/backend/src/runtime/node/ephemeral.js
@@ -1,0 +1,154 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { isPublishableKey } = require('@clerk/shared');
+
+async function createEphemeralAccount() {
+  const body = await postJSON('https://api.clerkstage.dev/v1/public/demo_instance');
+
+  const account = {
+    publishableKey: body.frontend_api_key,
+    secretKey: body.backend_api_key,
+    expiresAt: daysFromNow(1),
+  };
+
+  write(account);
+
+  return account;
+}
+
+async function fetchEphemeralAccount() {
+  const account = read();
+
+  if (account) {
+    const verified = await verifyEphemeralAccount(account);
+
+    if (verified) {
+      return account;
+    }
+  }
+
+  return await createEphemeralAccount();
+}
+
+async function verifyEphemeralAccount(account) {
+  // TODO: API not implemented yet.
+  //
+  // try {
+  //   await postJSON('https://api.clerkstage.dev/v1/ephemeral-account/verify', {
+  //     publishable_key: account.publishableKey,
+  //     secret_key: account.secretKey,
+  //   })
+  //
+  //   return true
+  //
+  // } catch (err) {
+  //   if (err instanceof ClientError) {
+  //     return false;
+  //   }
+  //
+  //   throw err;
+  // }
+
+  if (!isPublishableKey(account.publishableKey)) {
+    return false;
+  }
+
+  // NOTE: Simulate failed verification after 15 minutes
+  if (account.expiresAt < daysFromNow(1) - 60 * 15) {
+    return false;
+  }
+
+  return true;
+}
+
+const PATH = path.join(process.cwd(), 'node_modules', '.cache', 'clerkjs', 'ephemeral.json');
+
+function read() {
+  try {
+    if (fs.existsSync(PATH)) {
+      const config = JSON.parse(fs.readFileSync(PATH, { encoding: 'utf-8' }));
+
+      if (config.expiresAt < now()) {
+        return null;
+      }
+
+      return config;
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ENOENT')) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function write(obj) {
+  fs.mkdirSync(path.dirname(PATH), { recursive: true });
+
+  const content = JSON.stringify(obj);
+
+  fs.writeFileSync(PATH, content, {
+    encoding: 'utf8',
+    mode: '0777',
+    flag: 'w',
+  });
+}
+
+function postJSON(url, body) {
+  return apiResult(
+    fetch(url, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }),
+  );
+}
+
+async function apiResult(whenResponse) {
+  const response = await whenResponse;
+
+  if (response.status === 204) {
+    return null;
+  } else if (response.ok) {
+    const body = await response.json();
+    return body;
+  } else if (response.status >= 400 && response.status < 500) {
+    const body = await response.json();
+    const error = new ClientError(response.statusText, response.status, body);
+    throw error;
+  } else {
+    const error = new ServerError(response.statusText, response.status);
+    throw error;
+  }
+}
+
+class ClientError extends Error {
+  constructor(message, status, body) {
+    super(message);
+    this.status = status;
+    this.name = 'ClientError';
+    this.body = body;
+  }
+}
+
+class ServerError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.status = status;
+    this.name = 'ServerError';
+  }
+}
+
+function now() {
+  return daysFromNow(0);
+}
+
+function daysFromNow(days) {
+  return Math.floor(Date.now() / 1000) + 60 * 60 * 24 * days;
+}
+
+module.exports.fetchEphemeralAccount = fetchEphemeralAccount;

--- a/packages/backend/src/util/fetchEphemeralAccount.ts
+++ b/packages/backend/src/util/fetchEphemeralAccount.ts
@@ -1,0 +1,7 @@
+import type { EphemeralAccount } from '@clerk/types';
+
+import runtime from '../runtime';
+
+export function fetchEphemeralAccount(): Promise<EphemeralAccount> {
+  return runtime.fetchEphemeralAccount();
+}

--- a/packages/backend/tsup.config.test.ts
+++ b/packages/backend/tsup.config.test.ts
@@ -16,7 +16,7 @@ export default defineConfig(overrideOptions => {
       PACKAGE_VERSION: `"0.0.0-test"`,
       __DEV__: `${isWatch}`,
     },
-    external: ['#crypto'],
+    external: ['#crypto', '#ephemeral'],
     clean: true,
     minify: false,
     tsconfig: 'tsconfig.test.json',

--- a/packages/backend/tsup.config.ts
+++ b/packages/backend/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(overrideOptions => {
       PACKAGE_VERSION: `"${version}"`,
       __DEV__: `${isWatch}`,
     },
-    external: ['#crypto'],
+    external: ['#crypto', '#ephemeral'],
     bundle: true,
     clean: true,
     minify: false,

--- a/packages/fastify/src/__tests__/__snapshots__/constants.test.ts.snap
+++ b/packages/fastify/src/__tests__/__snapshots__/constants.test.ts.snap
@@ -9,6 +9,8 @@ exports[`constants from environment variables 1`] = `
     "DevBrowser": "__clerk_db_jwt",
     "Handshake": "__clerk_handshake",
     "Session": "__session",
+    "EphemeralPublishableKey": "__clerk_ephemeral_publishable_key",
+    "EphemeralSecretKey": "__clerk_ephemeral_secret_key",
   },
   "Headers": {
     "Accept": "accept",

--- a/packages/nextjs/src/app-router/server/ClerkProvider.tsx
+++ b/packages/nextjs/src/app-router/server/ClerkProvider.tsx
@@ -1,4 +1,7 @@
+import { constants, fetchEphemeralAccount } from '@clerk/backend/internal';
 import type { InitialState, Without } from '@clerk/types';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import React from 'react';
 
 import type { NextClerkProviderProps } from '../../types';
@@ -6,13 +9,39 @@ import { mergeNextClerkPropsWithEnv } from '../../utils/mergeNextClerkPropsWithE
 import { ClientClerkProvider } from '../client/ClerkProvider';
 import { initialState } from './auth';
 
-export function ClerkProvider(props: Without<NextClerkProviderProps, '__unstable_invokeMiddlewareOnAuthStateChange'>) {
+export async function ClerkProvider(
+  props: Without<NextClerkProviderProps, '__unstable_invokeMiddlewareOnAuthStateChange'>,
+) {
   const { children, ...rest } = props;
   const state = initialState()?.__clerk_ssr_state as InitialState;
 
+  const providerProps = { ...mergeNextClerkPropsWithEnv(rest) };
+
+  if (!providerProps.publishableKey) {
+    const ephemeralAccount = await fetchEphemeralAccount();
+    const params = new URLSearchParams();
+    const cookiePublishableKey = cookies().get(constants.QueryParameters.EphemeralPublishableKey)?.value;
+    const cookieSecretKey = cookies().get(constants.QueryParameters.EphemeralSecretKey)?.value;
+
+    if (!cookiePublishableKey || cookiePublishableKey !== ephemeralAccount.publishableKey) {
+      params.set(constants.QueryParameters.EphemeralPublishableKey, ephemeralAccount.publishableKey);
+    }
+
+    if (!cookieSecretKey || cookieSecretKey !== ephemeralAccount.secretKey) {
+      params.set(constants.QueryParameters.EphemeralSecretKey, ephemeralAccount.secretKey);
+    }
+
+    if (params.size === 2) {
+      redirect(`?${params}`);
+    }
+
+    providerProps.ephemeral = true;
+    providerProps.publishableKey = ephemeralAccount.publishableKey;
+  }
+
   return (
     <ClientClerkProvider
-      {...mergeNextClerkPropsWithEnv(rest)}
+      {...providerProps}
       initialState={state}
     >
       {children}

--- a/packages/nextjs/src/server/clerkMiddleware.ts
+++ b/packages/nextjs/src/server/clerkMiddleware.ts
@@ -8,6 +8,7 @@ import type {
   RequestState,
 } from '@clerk/backend/internal';
 import { AuthStatus, constants, createClerkRequest, createRedirect } from '@clerk/backend/internal';
+import { isClerkKeyError } from '@clerk/shared';
 import { eventMethodCalled } from '@clerk/shared/telemetry';
 import type { NextMiddleware } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -80,14 +81,12 @@ export const clerkMiddleware: ClerkMiddleware = withLogger('clerkMiddleware', lo
     logger.enable();
   }
 
-  const publishableKey = assertKey(params.publishableKey || PUBLISHABLE_KEY, () =>
-    errorThrower.throwMissingPublishableKeyError(),
-  );
-  const secretKey = assertKey(params.secretKey || SECRET_KEY, () => errorThrower.throwMissingSecretKeyError());
+  const publishableKey = params.publishableKey || PUBLISHABLE_KEY;
+  const secretKey = params.secretKey || SECRET_KEY;
   const signInUrl = params.signInUrl || SIGN_IN_URL;
   const signUpUrl = params.signUpUrl || SIGN_UP_URL;
 
-  const options = {
+  const runOptions = {
     ...params,
     publishableKey,
     secretKey,
@@ -95,16 +94,33 @@ export const clerkMiddleware: ClerkMiddleware = withLogger('clerkMiddleware', lo
     signUpUrl,
   };
 
-  return clerkMiddlewareRequestDataStore.run(options, () => {
+  const ephemeralMode = process.env.NODE_ENV === 'development' && (!params.publishableKey || !params.secretKey);
+  let ephemeralPublishableKey: string | undefined;
+  let ephemeralSecretKey: string | undefined;
+
+  return clerkMiddlewareRequestDataStore.run(runOptions, () => {
     clerkClient().telemetry.record(
       eventMethodCalled('clerkMiddleware', {
         handler: Boolean(handler),
-        satellite: Boolean(options.isSatellite),
-        proxy: Boolean(options.proxyUrl),
+        satellite: Boolean(runOptions.isSatellite),
+        proxy: Boolean(runOptions.proxyUrl),
       }),
     );
 
-    const nextMiddleware: NextMiddleware = async (request, event) => {
+    const baseNextMiddleware: NextMiddleware = async (request, event) => {
+      const publishableKey = assertKey(params.publishableKey || PUBLISHABLE_KEY || ephemeralPublishableKey || '', () =>
+        errorThrower.throwMissingPublishableKeyError(),
+      );
+      const secretKey = assertKey(params.secretKey || SECRET_KEY || ephemeralSecretKey || '', () =>
+        errorThrower.throwMissingSecretKeyError(),
+      );
+
+      const options = {
+        ...runOptions,
+        publishableKey,
+        secretKey,
+      };
+
       const clerkRequest = createClerkRequest(request);
       logger.debug('options', options);
       logger.debug('url', () => clerkRequest.toJSON());
@@ -164,6 +180,35 @@ export const clerkMiddleware: ClerkMiddleware = withLogger('clerkMiddleware', lo
       decorateRequest(clerkRequest, handlerResult, requestState, params);
 
       return handlerResult;
+    };
+
+    const nextMiddleware: NextMiddleware = async (request, event) => {
+      if (process.env.NODE_ENV !== 'development') {
+        return await baseNextMiddleware(request, event);
+      }
+
+      try {
+        if (ephemeralMode) {
+          const ephemeralKeys = Object.fromEntries(request.nextUrl.searchParams);
+          const queryEphemeralPublishableKey = ephemeralKeys[constants.QueryParameters.EphemeralPublishableKey];
+          const queryEphemeralSecretKey = ephemeralKeys[constants.QueryParameters.EphemeralSecretKey];
+
+          if (queryEphemeralPublishableKey && ephemeralPublishableKey !== queryEphemeralPublishableKey) {
+            ephemeralPublishableKey = queryEphemeralPublishableKey;
+          }
+          if (queryEphemeralSecretKey && ephemeralSecretKey !== queryEphemeralSecretKey) {
+            ephemeralSecretKey = queryEphemeralSecretKey;
+          }
+        }
+
+        return await baseNextMiddleware(request, event);
+      } catch (e: any) {
+        // And this is a clerkKeyError, return a no-op to allow the ClerkProvider to fetch the keys
+        if (isClerkKeyError(e)) {
+          return null;
+        }
+        throw e;
+      }
     };
 
     // If we have a request and event, we're being called as a middleware directly

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -39,6 +39,16 @@ export function isClerkAPIResponseError(err: any): err is ClerkAPIResponseError 
   return 'clerkError' in err;
 }
 
+// TODO: Find a better way to error when missing keys
+export function isClerkKeyError(err: any) {
+  const message = String(err);
+  return (
+    message.includes('Missing publishableKey') ||
+    message.includes('Missing secretKey') ||
+    message.includes("Clerk can't detect usage of clerkMiddleware()")
+  );
+}
+
 /**
  * Checks if the provided error object is an instance of ClerkRuntimeError.
  *

--- a/packages/types/src/key.ts
+++ b/packages/types/src/key.ts
@@ -4,3 +4,9 @@ export type PublishableKey = {
   frontendApi: string;
   instanceType: InstanceType;
 };
+
+export type EphemeralAccount = {
+  publishableKey: string;
+  secretKey: string;
+  expiresAt: number;
+};


### PR DESCRIPTION
## Description

Adds the ability for a user to use Clerk without signing up.

Note: We're currently using the staging demo account API for provisioning accounts, which means we need to point clerk towards their staging domain: `https://api.clerkstage.dev`.

## How to test
1. Use Next JS App server
2. Add `CLERK_API_URL=https://api.clerkstage.dev` to your `.env.development`
3. Use this version of Clerk
4. Ephemeral mode should be active!

## Checklist
- [ ] `npm test` runs as expected.
- [ ] `npm run build` runs as expected.
- [ ] (If applicable) [JSDoc comments](https://jsdoc.app/about-getting-started.html) have been added or updated for any package exports
- [ ] (If applicable) [Documentation](https://github.com/clerk/clerk-docs) has been updated

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🌟 New feature
- [ ] 🔨 Breaking change
- [ ] 📖 Refactoring / dependency upgrade / documentation
- [ ] other:
